### PR TITLE
Added missing lesson to Git series

### DIFF
--- a/rest/lessons1.json
+++ b/rest/lessons1.json
@@ -7,7 +7,7 @@
   {"name":"Java", "videos":["java-on-the-command-line", "installing-intellij-idea", "encapsulation", "inheritance", "polymorphism", "spring-boot", "spring-boot-default-port", "spring-mvc", "spring-mvc-serialization"]},
   {"name":"Databases", "videos":["sqlite"]},
   {"name":"Android", "videos":["android_emulator_skin_error", "android_studio_change_jdk", "installing_android_developer_studio", "android-hackathon"]},
-  {"name":"Git", "videos":["git-local-repository", "git-branching", "github", "github-pull-request", "sync-github-fork"]},
+  {"name":"Git", "videos":["easy-versioning-with-git", "git-local-repository", "git-branching", "github", "github-pull-request", "sync-github-fork"]},
   {"name":"Linux", "videos":["linux-navigating-the-command-line","linux-working-with-files","linux-vi","linux-file-permissions"]},
   {"name":"C", "videos":["linux-file-permissions","gdb-debugger"]},
   {"name":"Deployment", "videos":["ngrok", "hosting-static-html-sites-on-s3"]},


### PR DESCRIPTION
The Easy Versioning with Git lesson was showing up in the list of Git video from home page, but was not included in the previous / next navigation. Found that this lesson was not listed in lesson1.json, so I added it.
